### PR TITLE
Update ContextIO.js

### DIFF
--- a/lib/ContextIO.js
+++ b/lib/ContextIO.js
@@ -174,8 +174,10 @@ Client.prototype = (function () {
         var buf = new Buffer(length);
         length = 0;
         for (var i in tmp) {
-          tmp[i].copy(buf, length);
-          length += tmp[i].length;
+          if (tmp.hasOwnProperty(i)) {
+            tmp[i].copy(buf, length);
+            length += tmp[i].length;
+          }
         }
 
         var rBody = null;


### PR DESCRIPTION
check if prop is own property to avoid errors when objects/functions are extended.