### PR TITLE
Add sources/folders/messages handler

### DIFF
--- a/lib/ContextIO.js
+++ b/lib/ContextIO.js
@@ -633,6 +633,16 @@ Client.prototype = (function () {
                       _doCall.call(_obj, 'POST', _resourcePath, null, _parseArgs(arguments).cb);
                     }
                   }
+                },
+                'messages': function () {
+                  if (!_folderName) return null;
+                  _resourcePath += _folderName + '/messages';
+                  return {
+                    get: function () {
+                      var _args = _parseArgs(arguments);
+                      _doCall.call(_obj, 'GET', _resourcePath, _args.params, _args.cb);
+                    }
+                  }
                 }
               };
             },


### PR DESCRIPTION
see https://context.io/docs/2.0/accounts/sources/folders/messages

There was an expunge, but no messages handler, under sources/folders.