### PR TITLE
Add getFile method on message attachment resource

### DIFF
--- a/lib/lite/index.js
+++ b/lib/lite/index.js
@@ -88,7 +88,10 @@ module.exports = function (settings) {
                       resource += attachment_id ? 'attachments/' + encodeURIComponent(attachment_id) + '/' : 'attachments/'
 
                       return {
-                        get: _callService.get.bind(_callService, resource)
+                        get: _callService.get.bind(_callService, resource),
+                        getFile: function() {
+                          return _callService.getFile(resource, {})
+                        }
                       }
                     },
 

--- a/lib/lite/index.js
+++ b/lib/lite/index.js
@@ -89,9 +89,7 @@ module.exports = function (settings) {
 
                       return {
                         get: _callService.get.bind(_callService, resource),
-                        getFile: function() {
-                          return _callService.getFile(resource, {})
-                        }
+                        getFile: _callService.getFile.bind(_callService, resource)
                       }
                     },
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "tools",
     "rest"
   ],
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Aaron LaBrie <aaron@context.io>",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Add getFile method on message attachment resource in order to download attachment with BODY+HEADER response, example:

ctxioClient.users(config.contextio.userId).email_accounts(config.contextio.label).folders(folder).messages(messageId).attachments(attachmentId).getFile().then(function (ctxioClientRes) {
    res.set(ctxioClientRes.headers);
    res.send(ctxioClientRes.body);
  });